### PR TITLE
[SUBS-1304] Remove unnecessary call to file reference validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.subs'
-version '2.5.1-SNAPSHOT'
+version '2.5.2-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/uk/ac/ebi/subs/validator/core/handlers/AssayDataHandler.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/core/handlers/AssayDataHandler.java
@@ -35,17 +35,11 @@ public class AssayDataHandler extends AbstractHandler<AssayDataValidationMessage
     List<SingleValidationResult> validateSubmittable(AssayDataValidationMessageEnvelope envelope) {
         AssayData assayData = getAssayDataFromEnvelope(envelope);
 
-        List<SingleValidationResult> results = refValidator.validate(
+        return refValidator.validate(
                 assayData.getId(),
                 assayData.getAssayRefs(),
                 envelope.getAssays()
         );
-
-        if (!assayData.getFiles().isEmpty()) {
-            results.addAll(fileReferenceValidator.validate(assayData, envelope.getSubmissionId()));
-        }
-
-        return results;
     }
 
     @Override


### PR DESCRIPTION
In this code change I removed an unnecessary call to the file reference validator, because that check is already happening elsewhere in the validation-service. There is another queue `file-reference-assaydata-validation` that is subscribed too to the same routing key and that is triggering the file reference validation, already.